### PR TITLE
Converting Silicoids to Lithoids if DLC available

### DIFF
--- a/common/species_classes/00_r27_infested_species_classes.txt
+++ b/common/species_classes/00_r27_infested_species_classes.txt
@@ -8,6 +8,8 @@
 R27_infested_class = {
 	archetype = BIOLOGICAL
 
+	possible = { authority = { NOT = { value = auth_machine_intelligence text = SPECIES_CLASS_MUST_NOT_USE_MACHINE_INTELLIGENCE } } }
+
 	portraits = {	#actually this is portrait_groups naming must match in "... gfx\portraits\portraits"
 		"inf_palid"
 		"oth_horrorworm"

--- a/common/species_classes/00_r27_lithoid_species_classes.txt
+++ b/common/species_classes/00_r27_lithoid_species_classes.txt
@@ -5,12 +5,12 @@
 # can specify randomized=no to filter specified class from randomization.
 #	playable = trigger, default is yes, to specify if portraits are playable
 
-R27_silicoid_class = {
-	archetype = BIOLOGICAL
+R27_lithoid_class = {
+	archetype = LITHOID
 
 	possible = { authority = { NOT = { value = auth_machine_intelligence text = SPECIES_CLASS_MUST_NOT_USE_MACHINE_INTELLIGENCE } } }
 
-	playable = { has_lithoids = no }
+	playable = { has_lithoids = yes }
 
 	portraits = {	#actually this is portrait_groups naming must match in "... gfx\portraits\portraits"
 		"oth_silicoid_b_01"
@@ -31,4 +31,6 @@ R27_silicoid_class = {
 
 	resources = {}
 
+
+	trait = "trait_lithoid"
 }

--- a/common/species_classes/00_r27_normal_species_classes.txt
+++ b/common/species_classes/00_r27_normal_species_classes.txt
@@ -7,6 +7,9 @@
 
 R27_normal_class = {
 	archetype = BIOLOGICAL
+
+	possible = { authority = { NOT = { value = auth_machine_intelligence text = SPECIES_CLASS_MUST_NOT_USE_MACHINE_INTELLIGENCE } } }
+
 	portraits = {	#actually this is portrait_groups naming must match in "... gfx\portraits\portraits"
 		"oth_cat"
 		"mam_hyena"

--- a/common/species_classes/00_r27_robot_bio_species_classes.txt
+++ b/common/species_classes/00_r27_robot_bio_species_classes.txt
@@ -7,6 +7,9 @@
 
 R27_robot_bio_class = {
 	archetype = BIOLOGICAL
+
+	possible = { authority = { NOT = { value = auth_machine_intelligence text = SPECIES_CLASS_MUST_NOT_USE_MACHINE_INTELLIGENCE } } }
+
 	portraits = {	#actually this is portrait_groups naming must match in "... gfx\portraits\portraits"
 		"sil_humroid"
 		"sil_humansynth"

--- a/common/species_classes/00_r27_robot_bio_species_classes.txt
+++ b/common/species_classes/00_r27_robot_bio_species_classes.txt
@@ -27,6 +27,16 @@ R27_robot_bio_class = {
 		"me_geth"
 	}
 
+	custom_portraits = {
+		randomized = { always = no }
+		playable = { has_lithoids = yes }
+		portraits = {
+			"oth_silicoid_b_01"
+			"oth_silicoid_02"
+			"oth_silicoid_04"
+		}
+	}
+
 	# These should not be used for randomly generated species
 	non_randomized_portraits = {
 		"sil_humroid"

--- a/common/species_classes/00_r27_robot_species_classes.txt
+++ b/common/species_classes/00_r27_robot_species_classes.txt
@@ -8,10 +8,22 @@
 R27_robot_class = {
 	archetype = MACHINE
 	playable = { host_has_dlc = "Synthetic Dawn Story Pack" }
+	randomized = {
+		host_has_dlc = "Synthetic Dawn Story Pack"
+		# The create_species effect can't properly take the possible trigger below into account.
+		# Work around this by disabling this class for species randomization after game start.
+		NOT = { has_global_flag = game_started }
+	}
+	possible = { authority = { OR = { value = auth_machine_intelligence text = SPECIES_CLASS_MUST_USE_MACHINE_INTELLIGENCE } } }
+	possible_secondary = { always = no text = SECONDARY_SPECIES_CLASS_INVALID }
+
 	robotic = yes
 	gender = no
 	use_climate_preference = no
 	portrait_modding = yes    # allow changing portrait by robomodding
+
+	leader_age_min = 2
+	leader_age_max = 10
 
 	portraits = {	#actually this is portrait_groups naming must match in "... gfx\portraits\portraits"
 		"sil_humroid"
@@ -48,7 +60,6 @@ R27_robot_class = {
 		"me_geth"
 	}
 
-	randomized = yes
 	graphical_culture = mammalian_01
 	move_pop_sound_effect = "robot_pops_move"
 

--- a/common/species_classes/00_r27_silicoid_species_classes.txt
+++ b/common/species_classes/00_r27_silicoid_species_classes.txt
@@ -8,6 +8,8 @@
 R27_silicoid_class = {
 	archetype = BIOLOGICAL
 
+	possible = { authority = { NOT = { value = auth_machine_intelligence text = SPECIES_CLASS_MUST_NOT_USE_MACHINE_INTELLIGENCE } } }
+
 	portraits = {	#actually this is portrait_groups naming must match in "... gfx\portraits\portraits"
 		"oth_silicoid_b_01"
 		"oth_silicoid_02"

--- a/localisation/r27_portraits_l_english.yml
+++ b/localisation/r27_portraits_l_english.yml
@@ -5,7 +5,8 @@
  ####################################
 
 R27_normal_class:0 "R27 Biological"
-R27_silicoid_class:0 "R27 Silicoid"
+R27_silicoid_class:0 "R27 Lithoid"
 R27_infested_class:0 "R27 Infested"
 R27_robot_class:0 "R27 Machine"
-R27_robot_bio_class:0 "R27 BioMachine"
+R27_robot_bio_class:0 "R27 BioFake"
+R27_lithoid_class:0 "R27 Lithoid"

--- a/localisation/r27_portraits_l_german.yml
+++ b/localisation/r27_portraits_l_german.yml
@@ -5,7 +5,8 @@
  ####################################
 
 R27_normal_class:0 "R27 Biologisch"
-R27_silicoid_class:0 "R27 Silizoid"
+R27_silicoid_class:0 "R27 Lithoid"
 R27_infested_class:0 "R27 Infizierend"
 R27_robot_class:0 "R27 Maschine"
-R27_robot_bio_class:0 "R27 BioMech"
+R27_robot_bio_class:0 "R27 BioFake"
+R27_lithoid_class:0 "R27 Lithoid"


### PR DESCRIPTION
- Silicoid species class now only available if DLC not available
- Lithoid species class(same portraits like Silicoid) only available if DLC available 
- Also renaming BioMech to BioFake and inserting silicoids if DLC available
- BugFix: One could make an invalid mixed empire. Bio Ethics with machine pops, which leads to very unbalanced starting conditions (negative monthly credits, etc).

Fixes #4 